### PR TITLE
Add installing curl to Docker image creation

### DIFF
--- a/TemperatureService3/Dockerfile
+++ b/TemperatureService3/Dockerfile
@@ -16,6 +16,8 @@ ARG INFOVER="Pre-Release"
 RUN dotnet publish "TemperatureService3.csproj" -c Release -o /app /p:InformationalVersion=$INFOVER
 
 FROM base AS final
+RUN apt-get update && apt-get install -y --no-install-recommends curl
+
 WORKDIR /app
 COPY --from=publish /app .
 ENTRYPOINT ["dotnet", "TemperatureService3.dll"]


### PR DESCRIPTION
It seems that curl has been removed from the official ASP.NET Core 5.0 images (https://github.com/dotnet/dotnet-docker/pull/1657), but it is required here for healthchecks, so I am adding it in the last step before copying application files.